### PR TITLE
Propagate SFAuthenticationSession's errors

### DIFF
--- a/source/OAuth2Client.swift
+++ b/source/OAuth2Client.swift
@@ -136,7 +136,9 @@ open class OAuth2Client {
     
     if #available(iOS 11.0, *) {
       self.safariAuthenticator = SFAuthenticationSession(url: URL(string: urltext.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!)!, callbackURLScheme: self.configuration.redirectURL, completionHandler: { (url, error) in
-        if let url = url {
+        if let error = error {
+          self.clientDidFailLoadingToken(OAuth2Error(localizedTitle: "Authentication failed", localizedDescription: error.localizedDescription))
+        } else if let url = url {
           self.handle(redirectURL: url)
         }
       })


### PR DESCRIPTION
When SFAuthenticationSession reports error (for example, user taps 'cancel' in authentication dialog) - report it to clientDidFailLoadingToken instead of silently ignoring.